### PR TITLE
added path check for windows

### DIFF
--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -63,7 +63,10 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
       });
 
       var preset = path.dirname(relative.resolve('babel-preset-es2015/package.json', __dirname + '/../'));
-
+      // Windows path adjustment
+      if (process.platform === 'win32') {
+        preset = preset.replace(/\\/g, "\\\\");
+      }
       // Add an absolute path to the es2015 preset. Needed since host app
       // won't have the preset
       var mappedBabelRc = replace(babelRc, {


### PR DESCRIPTION
We are using ember-spaniel which uses this as a downstream dependency. Unfortunately the build breaks immediately on a Windows machine.

The `preset` path is not being resolved properly due to backslash issues. 

In this PR, a check has been added to verify the path on windows platform and delimit appropriately. 