### PR TITLE
Do not watch rollup's dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.0.2",
+    "broccoli-source": "^1.1.0",
     "broccoli-string-replace": "^0.1.1",
     "broccoli-wrap": "^0.0.2",
     "require-relative": "^0.8.7",

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -6,6 +6,7 @@ var path = require('path');
 var replace = require('broccoli-string-replace');
 var relative = require('require-relative');
 var Funnel = require('broccoli-funnel');
+var UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
 var es5Prefix = 'var _outputModule = (function() { var exports = {}; var module = { exports: exports };';
 var es5Postfix = 'return module.exports; })();';
@@ -52,7 +53,7 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
       var depFolder = path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath));
 
       // Add the babelrc file
-      var babelRc = new Funnel(__dirname + '/../', {
+      var babelRc = new Funnel(new UnwatchedDir(__dirname + '/../'), {
         include: ['rollup.babelrc'],
         getDestinationPath: function(relativePath) {
           if (relativePath === 'rollup.babelrc') {


### PR DESCRIPTION
Depending on how dependencies are installed (npm v2 vs npm v3 vs yarn &c.)
node_modules within rollup can be quite large.  We do not want to watch rollup's
dir, and we especially don't want to watch it when it can have a large
node_modules directory.  Besides causing problems from overwatching, it makes
recrawls and resyncs especially painful.