### PR TITLE
QuickFix to not watch dep folder

### DIFF
--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -50,7 +50,7 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
       var babelrcPath = path.dirname(main) + '/.babelrc';
 
       // Hacky way of getting the npm dependency folder
-      var depFolder = path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath));
+      var depFolder = new UnwatchedDir(path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath)));
 
       // Add the babelrc file
       var babelRc = new Funnel(new UnwatchedDir(__dirname + '/../'), {


### PR DESCRIPTION
A deps folder, may contain node_modules which tends to be rather large, and upsets file watchers.

Rebuilds of ember-rollup targets will still work, but changes in those targets will themselves not trigger a rebuild.