### PR TITLE
Replace usage of broccoli-wrap with broccoli-stew.map.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.0.2",
     "broccoli-source": "^1.1.0",
+    "broccoli-stew": "^1.4.0",
     "broccoli-string-replace": "^0.1.1",
-    "broccoli-wrap": "^0.0.2",
     "require-relative": "^0.8.7",
     "rollup-plugin-babel": "^2.6.1"
   }

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -1,7 +1,7 @@
 var rollup = require('broccoli-rollup');
 var merge = require('broccoli-merge-trees');
 var babel = require('rollup-plugin-babel');
-var wrapFiles = require('broccoli-wrap');
+var stew = require('broccoli-stew');
 var path = require('path');
 var replace = require('broccoli-string-replace');
 var relative = require('require-relative');
@@ -101,7 +101,9 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
         });
       } else {
         // If not ES6, bail out
-        var wrapped = wrapFiles(depFolder, { wrapper: [es5Prefix, es5Postfix] });
+        var wrapped = stew.map(depFolder, '*.js', function(content) {
+          return [es5Prefix, content, es5Postfix].join('');
+        });
         target = new Funnel(wrapped, {
           getDestinationPath: function(relativePath) {
             if (relativePath === main) {


### PR DESCRIPTION
broccoli-wrap results in an unstable output path. This replaces broccoli-wrap usage with a simple usage of `broccoli-stew`'s `map` to do the prefix/postfix.

Fixes #3