### PR TITLE
Use es2015-rollup plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-es2015-rollup": "^3.0.0",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.0.2",

--- a/rollup.babelrc
+++ b/rollup.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    ["es2015", { "modules": false }]
+    ["es2015-rollup"]
   ]
 }

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -63,7 +63,7 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
         }
       });
 
-      var preset = path.dirname(relative.resolve('babel-preset-es2015/package.json', __dirname + '/../'));
+      var preset = path.dirname(relative.resolve('babel-preset-es2015-rollup/package.json', __dirname + '/../'));
       // Windows path adjustment
       if (process.platform === 'win32') {
         preset = preset.replace(/\\/g, "\\\\");
@@ -73,7 +73,7 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
       var mappedBabelRc = replace(babelRc, {
         files: [ babelrcPath ],
         pattern: {
-          match: /es2015/g,
+          match: /es2015-rollup/g,
           replacement: preset
         }
       });


### PR DESCRIPTION
This is the same as es2015 except it excludes modules-commonjs and adds external-helpers.

https://github.com/rollup/babel-preset-es2015-rollup

This worked for me, but please test before merging.