### PR TITLE
Stop including node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "scripts": {},
   "dependencies": {
     "babel-preset-es2015": "^6.16.0",
-    "broccoli-funnel": "^1.0.7",
+    "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^1.1.4",
-    "broccoli-rollup": "^1.2.0",
+    "broccoli-rollup": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.4.0",
     "broccoli-string-replace": "^0.1.1",

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -51,6 +51,9 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
 
       // Hacky way of getting the npm dependency folder
       var depFolder = new UnwatchedDir(path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath)));
+      var depFolderClean = new Funnel(depFolder, {
+        exclude: ['node_modules', '.git']
+      });
 
       // Add the babelrc file
       var babelRc = new Funnel(new UnwatchedDir(__dirname + '/../'), {
@@ -84,7 +87,7 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
 
       if (esNext) {
         target = new rollup(merge([
-          depFolder,
+          depFolderClean,
           mappedBabelRc
         ]), {
           rollup: {


### PR DESCRIPTION
Instead, let newer version of broccoli-rollup handle node_modules