### PR TITLE
Pre build rollup dependencies independent of build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,27 @@
   "engines": {
     "node": ">= 0.5.0"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "mocha tests/",
+    "test:debug": "mocha debug tests/"
+  },
   "dependencies": {
     "babel-preset-es2015": "^6.16.0",
+    "broccoli-builder": "^0.18.8",
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.4.0",
     "broccoli-string-replace": "^0.1.1",
+    "chai": "^3.3.0",
+    "mocha": "^2.3.3",
     "require-relative": "^0.8.7",
     "rollup-plugin-babel": "^2.6.1"
+  },
+  "devDependencies": {
+    "console-ui": "2.1.0",
+    "ember-cli": "2.15.0",
+    "fixturify": "^0.3.0"
   }
 }

--- a/src/prebuild.js
+++ b/src/prebuild.js
@@ -1,0 +1,60 @@
+const fs = require('fs-extra');
+const path = require('path');
+const builder = require('broccoli-builder');
+const rollUpTree = require('./rollup-tree');
+const rollUp = require('./index');
+const Addon = require('ember-cli/lib/models/addon');
+const Project = require('ember-cli/lib/models/project');
+const UI = require('console-ui');
+const Merge = require('broccoli-merge-trees');
+const Funnel = require('broccoli-funnel');
+
+// Pre-build the dependency of an addon and store it in prebuilt path by invoking the treeForAddon and treeForVendor hook
+function preBuild(addonPath) {
+    // Require the addon
+    let addonToBuild = require(addonPath);
+    // Augment it with isDevelopingAddon function.
+    addonToBuild.isDevelopingAddon = function() {
+        return true;
+    }
+    // If addon has pre-built path set in it use that else use the default path
+    if(!addonToBuild.PREBUILT_PATH) {
+        addonToBuild.PREBUILT_PATH = `${addonPath}/pre-built`;
+    }
+    fs.removeSync(addonToBuild.PREBUILT_PATH);
+
+    const ui = new UI({
+        inputStream: process.stdin,
+        outputStream: process.stdout,
+        errorStream: process.stderr,
+        writeLevel: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR',
+        ci: true | false
+    });
+    // Extend the current addon from base Addon
+    const CurrentAddon = Addon.extend(Object.assign({}, addonToBuild, {root: addonPath}));
+    const project = new Project(addonPath, null, ui);
+    const currAddon  = new CurrentAddon(addonPath, project);
+
+    // Get the tree for Addon and Vendor
+    let addonTree = new Funnel (currAddon.treeFor('addon'), {
+        destDir:  'addon'
+    });
+
+    let vendorTree = new Funnel (currAddon.treeFor('vendor'), {
+        destDir:  'vendor'
+    });
+
+    // Merge, Build the resulting tree and store it in prebuild path
+    return build(Merge([addonTree, vendorTree]), addonToBuild.PREBUILT_PATH);
+ }
+
+function build(tree, prebuiltPath) {
+    if(tree) {
+        return new builder.Builder(tree).build().then(result => {
+            fs.copySync(result.directory, prebuiltPath);
+        });
+    }
+    return Promise.resolve();
+}
+
+module.exports = {preBuild, build };

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -1,20 +1,52 @@
-var rollup = require('broccoli-rollup');
-var merge = require('broccoli-merge-trees');
-var babel = require('rollup-plugin-babel');
-var stew = require('broccoli-stew');
-var path = require('path');
-var replace = require('broccoli-string-replace');
-var relative = require('require-relative');
-var Funnel = require('broccoli-funnel');
-var UnwatchedDir = require('broccoli-source').UnwatchedDir;
+const broccoliRollUp = require('broccoli-rollup');
+const merge = require('broccoli-merge-trees');
+const babel = require('rollup-plugin-babel');
+const stew = require('broccoli-stew');
+const path = require('path');
+const replace = require('broccoli-string-replace');
+const relative = require('require-relative');
+const Funnel = require('broccoli-funnel');
+const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
-var es5Prefix = 'var _outputModule = (function() { var exports = {}; var module = { exports: exports };';
-var es5Postfix = 'return module.exports; })();';
+let es5Prefix = 'let _outputModule = (function() { let exports = {}; let module = { exports: exports };';
+let es5Postfix = 'return module.exports; })();';
 es5Postfix += 'exports["default"] = _outputModule';
 
+function classifyDependencies(modules) {
+  let namespacedDependencies = [];
+  let nonNamespacedDependencies = [];
+  for (let i = 0; i < modules.length; i++) {
+    let moduleName = modules[i];
+    let namespaced = true;
+    let name;
+    if (typeof moduleName === 'string') {
+      name = moduleName;
+    } else {
+      name = moduleName.name;
+      namespaced = moduleName.namespaced;
+    }
+
+    let result = {
+      fileName: name.split('/').pop() + '.js',
+      moduleName: name,
+    };
+
+    if (namespaced) {
+      namespacedDependencies.push(result);
+    } else {
+      nonNamespacedDependencies.push(result);
+    }
+  }
+
+  return {
+    namespacedDependencies,
+    nonNamespacedDependencies
+  }
+}
+
 function shouldAddRuntimeDependencies() {
-  var current = this;
-  var app;
+  let current = this;
+  let app;
 
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
@@ -22,9 +54,9 @@ function shouldAddRuntimeDependencies() {
     app = current.app || app;
   } while (current.parent.parent && (current = current.parent));
 
-  var isTopLevelAddon = false;
-  for (var i = 0; i < this.project.addons.length; i++) {
-    var addon = this.project.addons[i];
+  let isTopLevelAddon = false;
+  for (let i = 0; i < this.project.addons.length; i++) {
+    let addon = this.project.addons[i];
     isTopLevelAddon = isTopLevelAddon || addon.name === this.name;
   }
 
@@ -34,102 +66,107 @@ function shouldAddRuntimeDependencies() {
   return !isTopLevelAddon || !this.parent.parent;
 }
 
-module.exports = function rollupAllTheThings(root, runtimeDependencies, superFunc, transpile) {
+function rollup(runtimeDependencies, nmPath, transpile) {
   transpile = !!transpile;
-  var nmPath = this.nodeModulesPath;
-  if (shouldAddRuntimeDependencies.call(this)) {
-    var trees = runtimeDependencies.map(function(dep) {
-      var esNext = true;
-      var pkg = relative(dep.moduleName + '/package.json', nmPath);
-      var main = pkg['jsnext:main'];
-      if (!main) {
-        main = pkg.main || 'index.js';
-        esNext = false;
+  let trees = runtimeDependencies.map(function(dep) {
+    let esNext = true;
+    let pkg = relative(dep.moduleName + '/package.json', nmPath);
+    let main = pkg['jsnext:main'];
+    if (!main) {
+      main = pkg.main || 'index.js';
+      esNext = false;
+    }
+
+    let babelrcPath = path.dirname(main) + '/.babelrc';
+    // Hacky way of getting the npm dependency folder
+    let depFolder = new UnwatchedDir(path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath)));
+    let depFolderClean = new Funnel(depFolder, {
+      exclude: ['node_modules', '.git']
+    });
+
+    // Add the babelrc file
+    let babelRc = new Funnel(new UnwatchedDir(__dirname + '/../'), {
+      include: ['rollup.babelrc'],
+      getDestinationPath: function(relativePath) {
+        if (relativePath === 'rollup.babelrc') {
+          return babelrcPath;
+        }
+        return relativePath;
       }
+    });
 
-      var babelrcPath = path.dirname(main) + '/.babelrc';
+    let preset = path.dirname(relative.resolve('babel-preset-es2015/package.json', __dirname + '/../'));
+    // Windows path adjustment
+    if (process.platform === 'win32') {
+      preset = preset.replace(/\\/g, "\\\\");
+    }
+    // Add an absolute path to the es2015 preset. Needed since host app
+    // won't have the preset
+    let mappedBabelRc = replace(babelRc, {
+      files: [ babelrcPath ],
+      pattern: {
+        match: /es2015/g,
+        replacement: preset
+      }
+    });
 
-      // Hacky way of getting the npm dependency folder
-      var depFolder = new UnwatchedDir(path.dirname(relative.resolve(dep.moduleName + '/package.json', nmPath)));
-      var depFolderClean = new Funnel(depFolder, {
-        exclude: ['node_modules', '.git']
+    let moduleDir = path.dirname(dep.moduleName);
+    let target;
+
+    if (esNext) {
+      target = new broccoliRollUp(merge([
+        depFolderClean,
+        mappedBabelRc
+      ]), {
+        rollup: {
+          entry: main,
+          targets: [{
+            dest: dep.fileName,
+            format: transpile ? 'amd' : 'es',
+            moduleId: dep.moduleName
+          }],
+          plugins: [
+            babel()
+          ]
+        }
       });
-
-      // Add the babelrc file
-      var babelRc = new Funnel(new UnwatchedDir(__dirname + '/../'), {
-        include: ['rollup.babelrc'],
+    } else {
+      // If not ES6, bail out
+      let wrapped = stew.map(depFolder, '*.js', function(content) {
+        return [es5Prefix, content, es5Postfix].join('');
+      });
+      target = new Funnel(wrapped, {
         getDestinationPath: function(relativePath) {
-          if (relativePath === 'rollup.babelrc') {
-            return babelrcPath;
+          if (relativePath === main) {
+            return dep.fileName;
           }
           return relativePath;
         }
       });
+    }
 
-      var preset = path.dirname(relative.resolve('babel-preset-es2015/package.json', __dirname + '/../'));
-      // Windows path adjustment
-      if (process.platform === 'win32') {
-        preset = preset.replace(/\\/g, "\\\\");
-      }
-      // Add an absolute path to the es2015 preset. Needed since host app
-      // won't have the preset
-      var mappedBabelRc = replace(babelRc, {
-        files: [ babelrcPath ],
-        pattern: {
-          match: /es2015/g,
-          replacement: preset
-        }
+    if (moduleDir === '.') {
+      return target;
+    } else {
+      return new Funnel(target, {
+        destDir: moduleDir
       });
+    }
+  });
 
-      var moduleDir = path.dirname(dep.moduleName);
+  let runtimeNpmTree = merge(trees.filter(Boolean));
+  return runtimeNpmTree;
+}
 
-      var target;
-
-      if (esNext) {
-        target = new rollup(merge([
-          depFolderClean,
-          mappedBabelRc
-        ]), {
-          rollup: {
-            entry: main,
-            targets: [{
-              dest: dep.fileName,
-              format: transpile ? 'amd' : 'es',
-              moduleId: dep.moduleName
-            }],
-            plugins: [
-              babel()
-            ]
-          }
-        });
-      } else {
-        // If not ES6, bail out
-        var wrapped = stew.map(depFolder, '*.js', function(content) {
-          return [es5Prefix, content, es5Postfix].join('');
-        });
-        target = new Funnel(wrapped, {
-          getDestinationPath: function(relativePath) {
-            if (relativePath === main) {
-              return dep.fileName;
-            }
-            return relativePath;
-          }
-        });
-      }
-
-      if (moduleDir === '.') {
-        return target;
-      } else {
-        return new Funnel(target, {
-          destDir: moduleDir
-        });
-      }
-    });
-
-    var runtimeNpmTree = merge(trees.filter(Boolean));
-
+function rollupAllTheThings(root, runtimeDependencies, superFunc, transpile) {
+  let nmPath = this.nodeModulesPath;
+  if (shouldAddRuntimeDependencies.call(this)) {
+    let runtimeNpmTree = rollup(runtimeDependencies, nmPath, transpile);
     return superFunc.call(this, merge([runtimeNpmTree, root].filter(Boolean)));
   } else {
     return superFunc.call(this, root);
   }
 }
+
+
+module.exports = { rollup, classifyDependencies, rollupAllTheThings}

--- a/tests/fixtures/dummy-addon/addon/index.js
+++ b/tests/fixtures/dummy-addon/addon/index.js
@@ -1,0 +1,1 @@
+// RAW node_modules/dummy-addon/addon/index.js

--- a/tests/fixtures/dummy-addon/index.js
+++ b/tests/fixtures/dummy-addon/index.js
@@ -1,0 +1,10 @@
+/* eslint node: true */
+const emberRollup = require('../../../src/index');
+const PREBUILT_PATH = `${__dirname}/pre-built`;
+const fs = require('fs');
+const rollupModule =  fs.readFileSync(`${__dirname}/rollup-module`, 'utf8');
+
+module.exports =  emberRollup([rollupModule], {
+    PREBUILT_PATH,
+    name: 'dummy-addon',
+});

--- a/tests/fixtures/dummy-addon/package.json
+++ b/tests/fixtures/dummy-addon/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "dummy-addon",
+    "version": "0.0.0",
+    "private": true,
+    "keywords": [
+      "ember-addon"
+    ],
+    "dependencies": {
+        "ember-inner-addon": "latest"
+    
+    }
+  }

--- a/tests/fixtures/dummy-addon/rollup-module
+++ b/tests/fixtures/dummy-addon/rollup-module
@@ -1,0 +1,1 @@
+ember-data

--- a/tests/prebuild-test.js
+++ b/tests/prebuild-test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const expect = require('chai').expect;
+const prebuildRollUp = require('../src/prebuild');
+const fs = require('fs-extra');
+const Funnel = require('broccoli-funnel');
+const fixturify = require('fixturify');
+const path = require('path');
+const preBuildPath = `${__dirname}/fixtures/dummy-addon/pre-built`;
+const FIXTURE_INPUT = `${__dirname}/fixtures/dir`;
+const rollupModule = `${__dirname}/fixtures/dummy-addon/rollup-module`;
+const addonPath = `${__dirname}/fixtures/dummy-addon`;
+
+describe('prebuild', function() {
+    afterEach(function() {
+        fs.removeSync(preBuildPath);
+        fs.removeSync(path.join(path.dirname(`${__dirname}`), '/tmp'));
+        let addon = require.resolve(addonPath);
+        delete require.cache[addon];
+    });
+
+    it('build dependency if it is present in node_modules', function() {
+        fs.writeFileSync(rollupModule, 'ember-inner-addon', "utf8");
+        let result = prebuildRollUp.preBuild(addonPath);
+        return result.then(() => {
+            expect(fs.readdirSync(preBuildPath)).to.deep.equal(['addon','vendor']);
+        });
+    });
+
+    it('throws an error when the dependency is not in node modules', function() {
+        fs.writeFileSync(rollupModule, 'ember-data', "utf8");
+        expect(function() {
+            prebuildRollUp.preBuild(addonPath)
+        }).to.throw(/Cannot find module \'ember-data\/package\.json\'/);
+    });
+
+});
+
+describe('build', function() {
+    beforeEach(function(){
+        fs.mkdirpSync(FIXTURE_INPUT);
+        fixturify.writeSync(FIXTURE_INPUT, {
+            dir1: {
+                subdir1: {
+                    'foo.js': ''
+                },
+                subdir2: {
+                    'bar.css': ''
+                },
+                'root-file.txt': ''
+                }
+        });
+    });
+
+    afterEach(function() {
+        fs.removeSync(FIXTURE_INPUT);
+        fs.removeSync(path.join(path.dirname(`${__dirname}`), '/tmp'));
+    });
+
+    it('stores the output in the given path', function() {
+        let tree = new Funnel(FIXTURE_INPUT + '/dir1', {
+            include: ['**/*.js']
+        });
+        let preBuildPath = path.join(FIXTURE_INPUT, "pre-built")
+        expect(function() {
+          fs.readdirSync(preBuildPath);
+        }).to.throw(/ENOENT.*pre-built/);
+
+        return prebuildRollUp.build(tree, preBuildPath).then(() => {
+            expect(fs.readdirSync(preBuildPath)).to.deep.equal(["subdir1"]);
+        });
+    });
+
+    it('throws if tree is null', function() {
+        let tree = null;
+        expect(function() {
+            prebuildRollUp.build(tree, preBuildPath);
+        }, /TypeError: Cannot read property \'rebuild\' of null/);
+    });
+});
+
+    

--- a/tests/rollup-tree-test.js
+++ b/tests/rollup-tree-test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const expect = require('chai').expect;
+const rollupTree = require('../src/rollup-tree');
+const path = require('path');
+const helpers = require('broccoli-test-helper');
+const createBuilder = helpers.createBuilder;
+const co = require('co');
+
+describe('rollup-tree', function() {
+    describe('classifyDependencies', function() {
+        it('classifies nonNamespacedDependencies', function() {
+            let dependencies = rollupTree.classifyDependencies([{name: 'broccoli-stew',  namespaced: false }]);
+            expect(dependencies.namespacedDependencies).to.deep.equal([]);
+            expect(dependencies.nonNamespacedDependencies).to.deep.equal([{ fileName: 'broccoli-stew.js', moduleName: 'broccoli-stew' } ]);
+        });
+
+        it('classifies namespacedDependencies', function() {
+            let dependencies = rollupTree.classifyDependencies([{name: 'broccoli-stew',  namespaced: true, }]);
+            expect(dependencies.namespacedDependencies).to.deep.equal([{ fileName: 'broccoli-stew.js', moduleName: 'broccoli-stew' } ]);
+            expect(dependencies.nonNamespacedDependencies).to.deep.equal([]);
+        });
+        
+        it('by default classifies dependency array of object to nonNamespacedDependencies ', function() {
+            let dependencies = rollupTree.classifyDependencies([{name: 'broccoli-stew' }]);
+            expect(dependencies.namespacedDependencies).to.deep.equal([]);
+            expect(dependencies.nonNamespacedDependencies).to.deep.equal([{ fileName: 'broccoli-stew.js', moduleName: 'broccoli-stew' } ]);
+        });
+
+        it('by default classifies dependency array of string to namespacedDependencies ', function() {
+            let dependencies = rollupTree.classifyDependencies(['broccoli-stew']);
+            expect(dependencies.namespacedDependencies).to.deep.equal([{ fileName: 'broccoli-stew.js', moduleName: 'broccoli-stew' } ]);
+            expect(dependencies.nonNamespacedDependencies).to.deep.equal([]);
+        });
+
+        it('does not throw for empty dependency array', function() {
+            let dependencies = rollupTree.classifyDependencies([]);
+            expect(dependencies.namespacedDependencies).to.deep.equal([]);
+            expect(dependencies.nonNamespacedDependencies).to.deep.equal([]);
+        });
+    });
+
+    describe('rollup', function() {
+        let output;
+        const addonPath = path.join(path.dirname(`${__dirname}`), 'node_modules');
+        afterEach(co.wrap(function* () {
+            yield output.dispose();
+        }));
+
+        it('rolls up a single module', co.wrap(function* () {
+            let dependencies = [{ fileName: 'spaniel.js', moduleName: 'spaniel' }];
+            let node = rollupTree.rollup(dependencies, addonPath);
+            output = createBuilder(node);
+            yield output.build();
+            expect(output.changes()).to.deep.equal({
+                "spaniel.js": "create"
+            });
+        }));
+
+        it('rolls up multiple modules', co.wrap(function* () {
+            let dependencies = [{ fileName: 'spaniel.js', moduleName: 'spaniel' }, { fileName: 'require-relative.js', moduleName: 'require-relative'}];
+            let node = rollupTree.rollup(dependencies, addonPath);
+            output = createBuilder(node);
+            yield output.build();
+            expect(output.changes()).to.deep.equal({
+                "README.md": "create",
+                "package.json": "create",
+                "require-relative.js": "create",
+                "spaniel.js": "create"
+            });
+        }));
+    });
+});


### PR DESCRIPTION
Enabling the rollup to be prebuilt when the addons are published to artifactory. This prevents the artifacts to be rebuilt every time app is started. 
Later when the addon makes a call to ember-rollup, a check is done to see if the prebuilt directory is already existing, if so returns the prebuilt directory instead of doing rollup.

