### PR TITLE
support the module option in package.json

### DIFF
--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -41,7 +41,8 @@ module.exports = function rollupAllTheThings(root, runtimeDependencies, superFun
     var trees = runtimeDependencies.map(function(dep) {
       var esNext = true;
       var pkg = relative(dep.moduleName + '/package.json', nmPath);
-      var main = pkg['jsnext:main'];
+      var main = pkg['jsnext:main'] || pkg['module'];
+
       if (!main) {
         main = pkg.main || 'index.js';
         esNext = false;


### PR DESCRIPTION
Some packages have adopted using `pkg.module` over `pkg.jsnext`. Luxon is one such package.

This commit adds a fallback of `module` if `jsnext` isn't found.

More info here: https://github.com/rollup/rollup/wiki/pkg.module