### PR TITLE
Fix bug when extending existing treeForAddon

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.16.0",
     "broccoli-builder": "^0.18.8",
     "broccoli-funnel": "^1.2.0",
-    "broccoli-merge-trees": "^1.1.4",
+    "broccoli-merge-trees": "^1.2.4",
     "broccoli-rollup": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.4.0",
@@ -38,8 +38,9 @@
     "rollup-plugin-babel": "^2.6.1"
   },
   "devDependencies": {
+    "broccoli-file-creator": "^2.1.1",
     "console-ui": "2.1.0",
-    "ember-cli": "2.15.0",
+    "ember-cli": "^3.3.0",
     "fixturify": "^0.3.0",
     "fs-extra": "5.0.0",
     "resolve": "1.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,10 @@ module.exports = function(modules, indexObj) {
       return rollupIntoTree.call(this, root, dependencies.namespacedDependencies, this._super.treeForAddon);
     }
     if (indexObj.treeForAddon) {
+      const originalTreeForAddon = indexObj.treeForAddon;
       indexObj.treeForAddon = function() {
         return merge([
-          indexObj.treeForAddon.apply(this, arguments),
+          originalTreeForAddon.apply(this, arguments),
           treeForAddon.apply(this, arguments)
         ]);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -27,25 +27,34 @@ module.exports = function(modules, indexObj) {
   let dependencies = classifyDependencies(modules);
 
   if (dependencies.namespacedDependencies.length > 0) {
-    function treeForAddon(root) {
+    function treeForAddon() {
       let preBuiltPath = getPreBuiltPath.call(this, indexObj);
       // Verify if dependency module is prebuilt already, if yes return the prebuilt path
       if(isPreBuilt(indexObj, path.join(preBuiltPath, ADDON))) {
         return path.join(preBuiltPath, ADDON);
       }
       // else rollup
-      return rollupIntoTree.call(this, root, dependencies.namespacedDependencies, this._super.treeForAddon);
+      return rollupIntoTree.call(this, dependencies.namespacedDependencies);
+    }
+    function treeForAddonWithSuper(root) {
+      return this._super.treeForAddon.call(this, merge([root, treeForAddon.apply(this)].filter(Boolean)));
     }
     if (indexObj.treeForAddon) {
       const originalTreeForAddon = indexObj.treeForAddon;
       indexObj.treeForAddon = function() {
+        // Must reference this._super for super to be available inside the treeForAddon functions
+        const __super = this._super;
+
+        // If a treeForAddon has already been implemented, assume it merges the super tree
+        // so we don't need to call super again
         return merge([
           originalTreeForAddon.apply(this, arguments),
           treeForAddon.apply(this, arguments)
         ]);
       }
     } else {
-      indexObj.treeForAddon = treeForAddon;
+      // If no treeForAddon is implemented, we need to merge the super tree
+      indexObj.treeForAddon = treeForAddonWithSuper;
     }
   }
 
@@ -56,18 +65,27 @@ module.exports = function(modules, indexObj) {
         return path.join(preBuiltPath, VENDOR);
       }
       // else rollup
-      return rollupIntoTree.call(this, root, dependencies.nonNamespacedDependencies, this._super.treeForVendor, true);
+      return rollupIntoTree.call(this, root, dependencies.nonNamespacedDependencies, true);
+    }
+    function treeForVendorWithSuper(root) {
+      return this._super.treeForVendor.call(this, merge([root, treeForVendor.apply(this)].filter(Boolean)));
     }
 
     if (indexObj.treeForVendor) {
+      // Must reference this._super for super to be available inside the treeForVendor functions
+      const __super = this._super;
+      const originalTreeForVendor = indexObj.treeForVendor;
       indexObj.treeForVendor = function() {
         return merge([
-          indexObj.treeForVendor.apply(this, arguments),
+          originalTreeForVendor.apply(this, arguments),
+          // If a treeForVendor has already been implemented, assume it merges the super tree
+          // so we don't need to call super again
           treeForVendor.apply(this, arguments)
         ]);
       }
     } else {
-      indexObj.treeForVendor = treeForVendor;
+      // If no treeForVendor is implemented, we need to merge the super tree
+      indexObj.treeForVendor = treeForVendorWithSuper;
     }
 
     function included() {

--- a/src/rollup-tree.js
+++ b/src/rollup-tree.js
@@ -161,12 +161,9 @@ function rollup(runtimeDependencies, transpile, addonRoot) {
   return runtimeNpmTree;
 }
 
-function rollupAllTheThings(root, runtimeDependencies, superFunc, transpile) {
+function rollupAllTheThings(runtimeDependencies, transpile) {
   if (shouldAddRuntimeDependencies.call(this)) {
-    let runtimeNpmTree = rollup(runtimeDependencies, transpile, this.root);
-    return superFunc.call(this, merge([runtimeNpmTree, root].filter(Boolean)));
-  } else {
-    return superFunc.call(this, root);
+    return rollup(runtimeDependencies, transpile, this.root);
   }
 }
 

--- a/tests/fixtures/dummy-addon/index.js
+++ b/tests/fixtures/dummy-addon/index.js
@@ -3,8 +3,20 @@ const emberRollup = require('../../../src/index');
 const PREBUILT_PATH = `${__dirname}/pre-built`;
 const fs = require('fs');
 const rollupModule =  fs.readFileSync(`${__dirname}/rollup-module`, 'utf8');
+const writeFile = require('broccoli-file-creator');
+var BroccoliMergeTrees = require('broccoli-merge-trees');
 
 module.exports =  emberRollup([rollupModule], {
     PREBUILT_PATH,
     name: 'dummy-addon',
+    treeForAddon() {
+        const tree = this._super.treeForAddon.apply(this, arguments);
+        const newFile = writeFile('/from-tree-for-addon.js', 'console.log("from treeForAddon");');
+        return new BroccoliMergeTrees([tree, newFile].filter(Boolean));
+    },
+    treeForVendor() {
+        const tree = this._super.treeForVendor.apply(this, arguments);
+        const newFile = writeFile('/from-tree-for-vendor.js', 'console.log("from treeFromVendor");');
+        return new BroccoliMergeTrees([tree, newFile].filter(Boolean));
+    }
 });

--- a/tests/fixtures/dummy-addon/node_modules/ember-inner-addon/package.json
+++ b/tests/fixtures/dummy-addon/node_modules/ember-inner-addon/package.json
@@ -9,8 +9,8 @@
     "loader.js": "latest"
   },
   "dependencies": {
-    "ember-cli-babel": "6.12.0",
-    "ember-cli": "~2.15.1"
+    "ember-cli-babel": "6.16.0",
+    "ember-cli": "~3.3.0"
   }
 }
 

--- a/tests/fixtures/dummy-addon/package.json
+++ b/tests/fixtures/dummy-addon/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "ember-inner-addon": "latest",
-        "ember-cli-babel": "6.12.0",
-        "ember-cli": "~2.15.1"
+        "ember-cli-babel": "6.16.0",
+        "ember-cli": "~3.3.0"
     }
   }

--- a/tests/prebuild-test.js
+++ b/tests/prebuild-test.js
@@ -25,6 +25,8 @@ describe('prebuild', function() {
         let result = prebuildRollUp.preBuild(addonPath);
         return result.then(() => {
             expect(fs.readdirSync(preBuildPath)).to.deep.equal(['addon','vendor']);
+            expect(fs.existsSync(`${preBuildPath}/addon/from-tree-for-addon.js`), 'Host addon treeForAddon still works').to.be.ok;
+            expect(fs.existsSync(`${preBuildPath}/vendor/from-tree-for-vendor.js`), 'Host addon treeForVendor still works').to.be.ok;
             let stats = fs.lstatSync(path.join(preBuildPath,'addon'));
 	        expect(stats.isSymbolicLink()).to.be.false;
 	    });


### PR DESCRIPTION
We should be calling the original function, instead of recursing infinitely on the new function.