### PR TITLE
Ensure project addons are initialized before project build

### DIFF
--- a/src/prebuild.js
+++ b/src/prebuild.js
@@ -29,6 +29,7 @@ function preBuild(addonPath) {
     ci: true | false
   });
   const project = Project.closestSync(addonPath, ui);
+  project.initializeAddons();
   // Extend the current addon from base Addon
   const CurrentAddon = Addon.extend(Object.assign({}, addonToBuild, {root: addonPath, pkg: project.pkg}));
   const currAddon  = new CurrentAddon(addonPath, project);


### PR DESCRIPTION
`ember-cli-babel@7` attempts to default to the project's babel config when building. Prior to this change, `this.projects.addons` is an empty array, resulting in any downstream addons that have `ember-cli-babel@7` will error.