### PR TITLE
Move dependencies only used in tests to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
     "broccoli-source": "^3.0.0",
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.1",
-    "broccoli-test-helper": "^2.0.0",
-    "chai": "^4.1.2",
-    "co": "^4.6.0",
-    "mocha": "^8.2.1",
     "require-relative": "^0.8.7",
     "rollup": "^2.33.1",
     "@rollup/plugin-babel": "5.2.1"
@@ -43,10 +39,14 @@
   "devDependencies": {
     "@xg-wang/whatwg-fetch": "^3.0.0",
     "broccoli-file-creator": "^2.1.1",
+    "broccoli-test-helper": "^2.0.0",
+    "chai": "^4.1.2",
+    "co": "^4.6.0",
     "console-ui": "3.1.2",
     "ember-cli": "^3.3.0",
     "fixturify": "^2.1.0",
     "fs-extra": "9.0.1",
+    "mocha": "^8.2.1",
     "resolve": "1.18.1",
     "spaniel": "2.6.3"
   }


### PR DESCRIPTION
This addon has several dependencies that are only used in tests. Moving them to devDependencies accordingly.